### PR TITLE
fix: release please workflow requires additional permission

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 name: release-please
 


### PR DESCRIPTION
- github API has apparently changed recently
- the release please workflow requires now an additional permission to create a `label` i.e. to make a new release
- see https://github.com/googleapis/release-please-action/issues/1105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to allow GitHub Actions to write to issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->